### PR TITLE
Korribu patch 3

### DIFF
--- a/lib/yumbootstrap/bdb.py
+++ b/lib/yumbootstrap/bdb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import sys
-import bsddb
+import berkeleydb
 
 #-----------------------------------------------------------------------------
 
@@ -10,10 +10,10 @@ import bsddb
 # should be the same as Yum/RPM use)
 def db_dump(filename, outfile = sys.stdout):
   try:
-    f = bsddb.hashopen(filename, 'r')
+    f = berkeleydb.hashopen(filename, 'r')
     db_type = "hash"
   except:
-    f = bsddb.btopen(filename, 'r')
+    f = berkeleydb.btopen(filename, 'r')
     db_type = "btree"
 
   outfile.write("VERSION=3\n") # magic

--- a/lib/yumbootstrap/yum.py
+++ b/lib/yumbootstrap/yum.py
@@ -4,9 +4,9 @@ import rpm as rpm_mod
 import os
 import shutil
 
-import bdb
-import sh
-import fs
+import yumbootstrap.bdb as bdb
+import yumbootstrap.sh as sh
+import yumbootstrap.fs as fs
 
 import logging
 logger = logging.getLogger("yum")


### PR DESCRIPTION
Библиотека bsddb3 больше не поддерживается (использовалась в файле bdb.py), заменена на [berkeleydb](https://pypi.org/project/berkeleydb/)